### PR TITLE
feat(llm-output): enforce JSON replies and log raw LLM output to `data/llm_raw/`

### DIFF
--- a/research/app/main.py
+++ b/research/app/main.py
@@ -45,19 +45,19 @@ app.mount('/static', _STATIC, name='static')
 
 @app.get('/', response_class=HTMLResponse)
 def landing(request: Request) -> HTMLResponse:
-    """Render landing page with language selector."""
+    """Show language selector."""
     return _render('language.html', request=request)
 
 
-@app.post('/', response_class=RedirectResponse)
+@app.post('/', response_class=RedirectResponse, status_code=303)
 def start_with_language(lang: str = Form(...)) -> RedirectResponse:
-    """Start a new session with selected language."""
-    sess_id = str(uuid.uuid4())
-    _SESSIONS[sess_id] = {
+    """Create a session after the physician chooses a language."""
+    sid = str(uuid.uuid4())
+    _SESSIONS[sid] = {
         'patient': {},
-        'meta': {'uuid': sess_id, 'lang': lang},
+        'meta': {'uuid': sid, 'lang': lang},
     }
-    return RedirectResponse(f'/demographics?sid={sess_id}', status_code=302)
+    return RedirectResponse(url=f'/demographics?sid={sid}', status_code=303)
 
 
 def _render(template: str, **context: Any) -> HTMLResponse:
@@ -72,6 +72,13 @@ def select_language(request: Request) -> HTMLResponse:
     return _render('language.html', request=request)
 
 
+def _session_or_404(sid: str) -> Dict[str, Any]:
+    """Return the session dict or raise 404."""
+    if sid not in _SESSIONS:
+        raise HTTPException(status_code=404, detail='Session expired')
+    return _SESSIONS[sid]
+
+
 @app.get('/', response_class=HTMLResponse)
 def start() -> HTMLResponse:
     """Kick-off page — redirects immediately to demographics step."""
@@ -81,13 +88,6 @@ def start() -> HTMLResponse:
         'meta': {'uuid': sess_id, 'lang': 'en'},
     }  # Default to English
     return RedirectResponse(f'/demographics?sid={sess_id}', status_code=302)
-
-
-def _session_or_404(sid: str) -> Dict[str, Any]:
-    """Return the session dict or raise 404."""
-    if sid not in _SESSIONS:
-        raise HTTPException(status_code=404, detail='Session expired')
-    return _SESSIONS[sid]
 
 
 @app.get('/demographics', response_class=HTMLResponse)
@@ -214,7 +214,7 @@ def diagnosis(request: Request, sid: str) -> HTMLResponse:
     """Handle diagnosis GET request."""
     sess = _session_or_404(sid)
     lang = sess['meta'].get('lang', 'en')
-    ai = diag.differential(sess['patient'], language=lang)
+    ai = diag.differential(sess['patient'], language=lang, session_id=sid)
     sess['ai_diag'] = ai.model_dump()
     return _render(
         'diagnosis.html',
@@ -241,12 +241,12 @@ def exams(request: Request, sid: str) -> HTMLResponse:
     """Handle exams GET request."""
     sess = _session_or_404(sid)
     lang = sess['meta'].get('lang', 'en')
-    ai = diag.exams(sess['selected_diagnoses'], language=lang)
+    ai = diag.exams(sess['selected_diagnoses'], language=lang, session_id=sid)
     sess['ai_exam'] = ai.model_dump()
     return _render(
         'exams.html',
         request=request,
-        sid=sid,
+        session_id=sid,
         summary=ai.summary,
         options=ai.options,
         lang=lang,

--- a/research/app/main.py
+++ b/research/app/main.py
@@ -215,13 +215,13 @@ def diagnosis(request: Request, sid: str) -> HTMLResponse:
     sess = _session_or_404(sid)
     lang = sess['meta'].get('lang', 'en')
     ai = diag.differential(sess['patient'], language=lang)
-    sess['ai_diag'] = ai
+    sess['ai_diag'] = ai.model_dump()
     return _render(
         'diagnosis.html',
         request=request,
         sid=sid,
-        summary=ai['summary'],
-        options=ai['options'],
+        summary=ai.summary,
+        options=ai.options,
         lang=lang,
     )
 
@@ -242,13 +242,13 @@ def exams(request: Request, sid: str) -> HTMLResponse:
     sess = _session_or_404(sid)
     lang = sess['meta'].get('lang', 'en')
     ai = diag.exams(sess['selected_diagnoses'], language=lang)
-    sess['ai_exam'] = ai
+    sess['ai_exam'] = ai.model_dump()
     return _render(
         'exams.html',
         request=request,
         sid=sid,
-        summary=ai['summary'],
-        options=ai['options'],
+        summary=ai.summary,
+        options=ai.options,
         lang=lang,
     )
 

--- a/src/sdx/agents/client.py
+++ b/src/sdx/agents/client.py
@@ -1,48 +1,46 @@
-"""Shared OpenAI helper for all agents."""
+"""
+Shared OpenAI helper used by all agents.
+
+* Forces JSON responses with `response_format={"type": "json_object"}`.
+* Delegates fence-stripping and Pydantic validation to
+  `LLMDiagnosis.from_llm`.
+"""
 
 from __future__ import annotations
 
-import json
 import os
 
 from pathlib import Path
-from typing import Any, Dict, cast
 
 from dotenv import load_dotenv
+from fastapi import HTTPException
 from openai import OpenAI
+from pydantic import ValidationError
 
-# load environment once (root/.envs/.env)
+from sdx.schema.clinical_outputs import LLMDiagnosis
+
 load_dotenv(Path(__file__).parents[3] / '.envs' / '.env')
 
-_MODEL_NAME = 'o4-mini-2025-04-16'
+_MODEL_NAME = os.getenv('OPENAI_MODEL', 'o4-mini-2025-04-16')
 _client = OpenAI(api_key=os.getenv('OPENAI_API_KEY', ''))
 
 
-def chat(system: str, user: str) -> Dict[str, Any]:
-    """Return parsed JSON from the first chat completion.
-
-    Parameters
-    ----------
-    system
-        System role instructions.
-    user
-        User prompt (plain text or JSON string).
-
-    Raises
-    ------
-    ValueError
-        If the model does not return valid JSON.
-    """
+def chat(system: str, user: str) -> LLMDiagnosis:
+    """Send a system/user prompt and return a validated ``LLMDiagnosis``."""
     rsp = _client.chat.completions.create(
         model=_MODEL_NAME,
+        response_format={'type': 'json_object'},
         messages=[
             {'role': 'system', 'content': system},
             {'role': 'user', 'content': user},
         ],
     )
+
+    raw: str = rsp.choices[0].message.content or '{}'
+
     try:
-        return cast(
-            Dict[str, Any], json.loads(rsp.choices[0].message.content or '{}')
-        )
-    except json.JSONDecodeError as exc:  # pragma: no cover
-        raise ValueError('OpenAI response is not valid JSON') from exc
+        return LLMDiagnosis.from_llm(raw)
+    except ValidationError as exc:  # JSON syntax or schema error
+        raise HTTPException(
+            422, f'LLM response is not valid LLMDiagnosis: {exc}'
+        ) from exc

--- a/src/sdx/agents/client.py
+++ b/src/sdx/agents/client.py
@@ -1,15 +1,17 @@
 """
 Shared OpenAI helper used by all agents.
 
-* Forces JSON responses with `response_format={"type": "json_object"}`.
-* Delegates fence-stripping and Pydantic validation to
-  `LLMDiagnosis.from_llm`.
+* Forces JSON responses (`response_format={"type": "json_object"}`).
+* Validates with ``LLMDiagnosis.from_llm``.
+* Persists every raw reply under ``data/llm_raw/<sid>_<UTC>.json``.
 """
 
 from __future__ import annotations
 
 import os
+import uuid
 
+from datetime import datetime, timezone
 from pathlib import Path
 
 from dotenv import load_dotenv
@@ -24,9 +26,28 @@ load_dotenv(Path(__file__).parents[3] / '.envs' / '.env')
 _MODEL_NAME = os.getenv('OPENAI_MODEL', 'o4-mini-2025-04-16')
 _client = OpenAI(api_key=os.getenv('OPENAI_API_KEY', ''))
 
+_RAW_DIR = Path('data') / 'llm_raw'
+_RAW_DIR.mkdir(parents=True, exist_ok=True)
 
-def chat(system: str, user: str) -> LLMDiagnosis:
-    """Send a system/user prompt and return a validated ``LLMDiagnosis``."""
+
+def dump_llm_json(text: str, sid: str | None) -> None:
+    """
+    Save *text* to data/llm_raw/<timestamp>_<sid>.json.
+
+    If *sid* is None, a random 8-char token is used instead.
+    """
+    ts = datetime.now(timezone.utc).strftime('%Y%m%dT%H%M%SZ')
+    suffix = sid or uuid.uuid4().hex[:8]
+    (_RAW_DIR / f'{ts}_{suffix}.json').write_text(text, encoding='utf-8')
+
+
+def chat(
+    system: str,
+    user: str,
+    *,
+    session_id: str | None = None,
+) -> LLMDiagnosis:
+    """Send system / user prompts and return a validated ``LLMDiagnosis``."""
     rsp = _client.chat.completions.create(
         model=_MODEL_NAME,
         response_format={'type': 'json_object'},
@@ -37,10 +58,11 @@ def chat(system: str, user: str) -> LLMDiagnosis:
     )
 
     raw: str = rsp.choices[0].message.content or '{}'
+    dump_llm_json(raw, session_id)
 
     try:
         return LLMDiagnosis.from_llm(raw)
-    except ValidationError as exc:  # JSON syntax or schema error
+    except ValidationError as exc:
         raise HTTPException(
             422, f'LLM response is not valid LLMDiagnosis: {exc}'
         ) from exc

--- a/src/sdx/agents/diagnostics/core.py
+++ b/src/sdx/agents/diagnostics/core.py
@@ -74,17 +74,29 @@ _EXAM_PROMPTS = {
 
 
 def differential(
-    patient: Dict[str, Any], language: str = 'en'
+    patient: Dict[str, Any],
+    language: str = 'en',
+    session_id: str | None = None,
 ) -> LLMDiagnosis:
     """Return summary + list of differential diagnoses."""
     prompt = _DIAG_PROMPTS.get(language, _DIAG_PROMPTS['en'])
-    return chat(prompt, json.dumps(patient, ensure_ascii=False))
+    return chat(
+        prompt,
+        json.dumps(patient, ensure_ascii=False),
+        session_id=session_id,
+    )
 
 
-def exams(selected_dx: List[str], language: str = 'en') -> LLMDiagnosis:
+def exams(
+    selected_dx: List[str], language: str = 'en', session_id: str | None = None
+) -> LLMDiagnosis:
     """Return summary + list of suggested examinations."""
     prompt = _EXAM_PROMPTS.get(language, _EXAM_PROMPTS['en'])
-    return chat(prompt, json.dumps(selected_dx, ensure_ascii=False))
+    return chat(
+        prompt,
+        json.dumps(selected_dx, ensure_ascii=False),
+        session_id=session_id,
+    )
 
 
 __all__ = ['differential', 'exams']

--- a/src/sdx/agents/diagnostics/core.py
+++ b/src/sdx/agents/diagnostics/core.py
@@ -7,6 +7,7 @@ import json
 from typing import Any, Dict, List
 
 from sdx.agents.client import chat
+from sdx.schema.clinical_outputs import LLMDiagnosis
 
 _DIAG_PROMPTS = {
     'en': (
@@ -74,13 +75,13 @@ _EXAM_PROMPTS = {
 
 def differential(
     patient: Dict[str, Any], language: str = 'en'
-) -> Dict[str, Any]:
+) -> LLMDiagnosis:
     """Return summary + list of differential diagnoses."""
     prompt = _DIAG_PROMPTS.get(language, _DIAG_PROMPTS['en'])
     return chat(prompt, json.dumps(patient, ensure_ascii=False))
 
 
-def exams(selected_dx: List[str], language: str = 'en') -> Dict[str, Any]:
+def exams(selected_dx: List[str], language: str = 'en') -> LLMDiagnosis:
     """Return summary + list of suggested examinations."""
     prompt = _EXAM_PROMPTS.get(language, _EXAM_PROMPTS['en'])
     return chat(prompt, json.dumps(selected_dx, ensure_ascii=False))

--- a/src/sdx/schema/__init__.py
+++ b/src/sdx/schema/__init__.py
@@ -1,1 +1,5 @@
 """Schema package."""
+
+from .clinical_outputs import LLMDiagnosis
+
+__all__ = ['LLMDiagnosis']


### PR DESCRIPTION
### **Description**
- Closes #20.
* Force the `response_format={"type": "json_object"}` parameter in every `OpenAI.chat.completions.create` call, ensuring the model is instructed to emit JSON only.
* Add a helper that saves each *raw* LLM reply to `data/llm_raw/<sid>_<UTC>.json` for debugging/audit.
* Return a 422 with a clear message if validation still fails.

